### PR TITLE
Make some of the functions const

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.32.0
+          toolchain: 1.46.0
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A library for working with X11 keysyms"
 repository = "https://github.com/notgull/xkeysym"
 license = "BSL-1.0"
 keywords = ["x11", "keysym", "keysyms"]
-rust-version = "1.32.0"
+rust-version = "1.46.0"
 
 [dev-dependencies]
 bytemuck = "1.12.3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In addition, this crate contains no unsafe code and is fully compatible with `no
 
 ## MSRV Policy
 
-The Minimum Safe Rust Version for this crate is **1.32.0**.
+The Minimum Safe Rust Version for this crate is **1.46.0**.
 
 ## License
 

--- a/keysym-generator/src/main.rs
+++ b/keysym-generator/src/main.rs
@@ -65,7 +65,7 @@ use super::Keysym;
 /// 
 /// The output of this function is not stable and is intended for debugging purposes.
 #[allow(unreachable_patterns)]
-pub fn name(keysym: Keysym) -> Option<&'static str> {
+pub const fn name(keysym: Keysym) -> Option<&'static str> {
     match keysym {
 "
     .to_string();

--- a/src/automatically_generated.rs
+++ b/src/automatically_generated.rs
@@ -2562,7 +2562,7 @@ pub const KEY_block: Keysym = 0x100000fc;
 /// 
 /// The output of this function is not stable and is intended for debugging purposes.
 #[allow(unreachable_patterns)]
-pub fn name(keysym: Keysym) -> Option<&'static str> {
+pub const fn name(keysym: Keysym) -> Option<&'static str> {
     match keysym {
         KEY_VoidSymbol => Some("XK_VoidSymbol"),
         KEY_BackSpace => Some("XK_BackSpace"),


### PR DESCRIPTION
Some of the functions here can be made `const`, except for `key_char` and `keysym`, since they require some hacks.